### PR TITLE
Fix a typo

### DIFF
--- a/values.go
+++ b/values.go
@@ -47,7 +47,7 @@ func (v *values[T]) put(value T) (uint32, error) {
 	default:
 		keyProvider, ok := any(value).(KeyProvider)
 		if !ok {
-			return 0, fmt.Errorf("unhashable type %T, consifer implementing Hash() int", value)
+			return 0, fmt.Errorf("unhashable type %T, consider implementing Key() interface{}", value)
 		}
 		key = keyProvider.Key()
 	}


### PR DESCRIPTION
There is a typo in error message make misguiding to user to implement the hash interface, please fix it